### PR TITLE
Remove refs to yarn from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ In this project, you build an app that let's you display a todo list from reduce
 
 - [ ] Create a forked copy of this project.
 - [ ] Add your team lead as collaborator on Github.
-- [ ] Clone your OWN version of the repository in your terminal
-- [ ] CD into the project base directory `cd reducer-todo`
-- [ ] Create a new react app using CRA
-- [ ] Using the same command tool (yarn or npm) start up the app using `yarn start` or `npm start`
+- [ ] Clone your OWN version of the repository in your terminal.
+- [ ] CD into the project base directory `cd reducer-todo`.
+- [ ] Create a new react app running `npx create-react-app todo --use-npm`.
+- [ ] CD into the react app directory `cd todo`.
+- [ ] Start up the app using `npm start`.
 - [ ] Create a new branch: git checkout -b `<firstName-lastName>`.
 - [ ] Implement the project on your newly created `<firstName-lastName>` branch, committing changes regularly.
 - [ ] Push commits: git push origin `<firstName-lastName>`.


### PR DESCRIPTION
- Remove refs to yarn from README
- Instruct to use npx and the --use-npm flag when generating a CRA app